### PR TITLE
WIP: Remove deprecated rollup hook `onwrite`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,11 @@ export default (opt = {}) => {
 
 	return {
 		name: 'html',
-		onwrite(config, data) {
+		generateBundle(config, data, isWrite) {
+			if (isWrite) {
+				return;
+			}
+
 			const isHTML = /^.*<html>.*<\/html>$/.test(template);
 			const $ = cheerio.load(isHTML?template:readFileSync(template).toString());
 			const head = $('head');


### PR DESCRIPTION
Rollup deprecated the `onwrite` hook in [v1.0.0](https://github.com/rollup/rollup/blob/master/CHANGELOG.md#100).
This PR integrates the `generateBundle` which is [recommended by the rollup team](https://rollupjs.org/guide/en#deprecated). For this new hook the bundles should be traversed in-memory as the hook is actually called before writing the files to disk.