### PR TITLE
Replace deprecated `onwrite` hook with `writeBundle`

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "eslint": "^5.0.1",
     "jasmine": "^3.1.0",
-    "rollup": "^0.62.0",
+    "rollup": "^1.1.0",
     "rollup-plugin-buble": "^0.19.2",
     "rollup-plugin-commonjs": "^9.1.3",
     "rollup-plugin-node-resolve": "^3.0.0"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,10 +4,10 @@ import buble from 'rollup-plugin-buble';
 const pkg = require('./package.json');
 
 export default {
-  entry: 'src/index.js',
-  targets: [
-    { format: 'cjs', dest: pkg['main'] },
-    { format: 'es', dest: pkg['module'] }
+  input: 'src/index.js',
+  output: [
+    { format: 'cjs', file: pkg['main'] },
+    { format: 'es', file: pkg['module'] }
   ],
   external: ['fs', 'path', 'crypto'],
   plugins: [

--- a/src/index.js
+++ b/src/index.js
@@ -29,15 +29,19 @@ export default (opt = {}) => {
 
 	return {
 		name: 'html',
-		onwrite(config, data) {
+		writeBundle(config, data) {
 			const isHTML = /^.*<html>.*<\/html>$/.test(template);
 			const $ = cheerio.load(isHTML?template:readFileSync(template).toString());
 			const head = $('head');
 			const body = $('body');
-			const { file, sourcemap } = config;
+			let entryConfig = {};
+			Object.values(config).forEach((c) => {
+				if (c.isEntry) entryConfig = c
+			})
+			const { fileName,	sourcemap } = entryConfig
 			const fileList = [];
 			// relative('./', file) will not be equal to file when file is a absolute path
-			const destPath = relative('./', file);
+			const destPath = relative('./', fileName);
 			const destDir = dest || destPath.slice(0, destPath.indexOf(pathSeperator));
 			const destFile = `${destDir}/${filename || basename(template)}`;
 
@@ -86,9 +90,9 @@ export default (opt = {}) => {
 				}
 
 				let src = isURL(file) ? file : relative(destDir, file);
-				
+
 				if (node.timestamp) {
-                    src += '?t=' + (new Date()).getTime(); 
+                    src += '?t=' + (new Date()).getTime();
 				}
 
 				if (type === 'js') {


### PR DESCRIPTION
I am not very familiar with rollup, but it seems in addition to deprecating the `onwrite` hook, the first parameter that is passed to the `writeBundle` hook is now an object with all entry points and the prop `file` was renamed to `fileName`. Not sure if there is a better way to handle this than a `forEach` loop, but it seems to work fine the way it is now.