### PR TITLE
Add type declarations & `async` + `defer` options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,20 @@
+export = bundleHtmlPlugin
+
+declare function bundleHtmlPlugin (options?: BundleHtmlPluginOptions): import('rollup').Plugin
+
+interface BundleHtmlPluginOptions {
+  template: string
+  dest: string
+  filename?: string
+  inject?: 'head' | 'body'
+  externals?: ExternalResource[]
+  absolute?: boolean
+  async?: boolean
+  defer?: boolean
+}
+
+interface ExternalResource {
+  type: string
+  file: string
+  pos: 'before' | string
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "bugs": "https://github.com/haifeng2013/rollup-plugin/issues",
   "author": "louisx",
   "license": "MIT",
+  "types": "index.d.ts",
   "files": [
     "src",
     "dist",

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ function isURL(url){
 }
 
 export default (opt = {}) => {
-	const { template, filename, externals, inject, dest, absolute, defer } = opt;
+	const { template, filename, externals, inject, dest, absolute, async, defer } = opt;
 
 	return {
 		name: 'html',
@@ -97,7 +97,7 @@ export default (opt = {}) => {
 				}
 
 				if (type === 'js') {
-					const script = `<script type="text/javascript" src="${src}" ${defer ? 'defer' : ''}></script>\n`;
+					const script = `<script type="text/javascript" src="${src}" ${async ? 'async' : ''} ${defer ? 'defer' : ''}></script>\n`;
 					// node.inject will cover the inject
 					if (node.inject === 'head' || inject === 'head') {
 						head.append(script);

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ function isURL(url){
 }
 
 export default (opt = {}) => {
-	const { template, filename, externals, inject, dest, absolute } = opt;
+	const { template, filename, externals, inject, dest, absolute, defer } = opt;
 
 	return {
 		name: 'html',
@@ -97,7 +97,7 @@ export default (opt = {}) => {
 				}
 
 				if (type === 'js') {
-					const script = `<script type="text/javascript" src="${src}"></script>\n`;
+					const script = `<script type="text/javascript" src="${src}" ${defer ? 'defer' : ''}></script>\n`;
 					// node.inject will cover the inject
 					if (node.inject === 'head' || inject === 'head') {
 						head.append(script);


### PR DESCRIPTION
This commit adds type declarations as well as two new options:

**async**
When `true`, it will prepend `async` to the script tag.

**defer**
When `true`, it will prepend `defer` to the script tag.