### PR TITLE
Add an 'ignore' parameter to ignore files matching the specified regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ export default {
   input: 'src/main.js',
   output: {
     file: 'dist/foo/bundle.js',
-  },        
+  },
   plugins: [
     html({
         template: 'src/template.html',
@@ -59,7 +59,7 @@ export default {
 
 ## Hash
 
-You can set string '[hash]' for output file in rollup.config.js, and your bundle and source map (if you turned on 
+You can set string '[hash]' for output file in rollup.config.js, and your bundle and source map (if you turned on
 sourcemap option) will have the string '[hash]' be replaced by its hash.
 ```js
 export default {
@@ -67,23 +67,23 @@ export default {
   output: {
     file: 'dist/foo/bundle-[hash].js',
     // Turn on sourcemap
-    sourcemap: true  
-  },        
+    sourcemap: true
+  },
   plugins: [
     ...
   ]
 };
 ```
 You will find both bundle and map files are hashed and placed in your `dist/foo` folder:
- `bundle-76bf4fb5dbbd62f0fa3708aa3d8a9350.js`, `bundle-84e0f899735b1e320e625c9a5c7c49a7.js.map` 
+ `bundle-76bf4fb5dbbd62f0fa3708aa3d8a9350.js`, `bundle-84e0f899735b1e320e625c9a5c7c49a7.js.map`
 
 ## Options
 
 You can pass an option to the `html()` just like above, and there are some options:
 
-- template: Required. either path or code string of the template file, template should 
+- template: Required. either path or code string of the template file, template should
   be a html file.
-- filename: Optional if 'template' is a path. the name of the result html file, if omitted, 
+- filename: Optional if 'template' is a path. the name of the result html file, if omitted,
   will use name in template as file name.
 - externals: Optional. a list of files which will be insert into the resule
   html. The file should be a valid url.
@@ -98,6 +98,7 @@ You can pass an option to the `html()` just like above, and there are some optio
   If no mode is specified, the `type` attribute is omitted. Externals can
   optionally override this per file.
 - dest: Optional. the folder in which js file is searched and be injected to html file.
+- ignore: Optional. specify a regex that will prevent all matching files from being injected.
 
 ## License
 

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ function isURL(url){
 }
 
 export default (opt = {}) => {
-	const { template, filename, externals, inject, dest, absolute } = opt;
+	const { template, filename, externals, inject, dest, absolute, ignore } = opt;
 
 	return {
 		name: 'html',
@@ -61,6 +61,11 @@ export default (opt = {}) => {
 
 			fileList.forEach(node => {
 				let { type, file } = node;
+
+				if (ignore && file.match(ignore)) {
+					return;
+				}
+
 				let hash = '';
 				let code = '';
 


### PR DESCRIPTION
This change adds an `ignore` parameter that allows to specify a regex for more fine-grained control over the injected files. If `ignore` is provided, all candidates for injection will be tested against this regex and ignored if they match.

My usecase: I have a set of web workers in my target directory which must not be loaded from the generated HTML.