### PR TITLE
 Add prefix option to deploy on CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ export default {
 You will find both bundle and map files are hashed and placed in your `dist/foo` folder:
  `bundle-76bf4fb5dbbd62f0fa3708aa3d8a9350.js`, `bundle-84e0f899735b1e320e625c9a5c7c49a7.js.map`
 
-## prefix
+## onlinePath
 
-You can set 'prefix' as anything like `//www.sohu.com/` if you want to put the files on CDN after building.
+You can set 'onlinePath' as anything like `//www.sohu.com/` if you want to put the files on CDN after building.
 
 ```js
 {
@@ -91,7 +91,7 @@ You can set 'prefix' as anything like `//www.sohu.com/` if you want to put the f
     html({
         dest: "dist/foo",
         // ...
-        prefix: '//www.sohu.com/dist/foo'
+        onlinePath: '//www.sohu.com/dist/foo'
     })
   ]
 }

--- a/README.md
+++ b/README.md
@@ -77,6 +77,28 @@ export default {
 You will find both bundle and map files are hashed and placed in your `dist/foo` folder:
  `bundle-76bf4fb5dbbd62f0fa3708aa3d8a9350.js`, `bundle-84e0f899735b1e320e625c9a5c7c49a7.js.map`
 
+## prefix
+
+You can set 'prefix' as anything like `//www.sohu.com/` if you want to put the files on CDN after building.
+
+```js
+{
+  output: {
+    file: 'dist/foo/main.js',
+  },
+  // ...
+  plugins: [
+    html({
+        dest: "dist/foo",
+        // ...
+        prefix: '//www.sohu.com/dist/foo'
+    })
+  ]
+}
+```
+
+and you will get something like: `<script src="//www.sohu.com/dist/foo/main.js"></script>`.
+
 ## Options
 
 You can pass an option to the `html()` just like above, and there are some options:
@@ -100,6 +122,8 @@ You can pass an option to the `html()` just like above, and there are some optio
 - __dest__: (*optional*) the folder in which js file is searched and be injected to html file.
 - __absolute__: (*optional*) indicates is paths of injected files should starts with "/".
 - __ignore__: (*optional*) specify a regex that will prevent all matching files from being injected.
+- __prefix__: (*optional*) add a prefix to the file while bundle file would be 
+  pushed into CDN instead of a local file.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ You can pass an option to the `html()` just like above, and there are some optio
 - __dest__: (*optional*) the folder in which js file is searched and be injected to html file.
 - __absolute__: (*optional*) indicates is paths of injected files should starts with "/".
 - __ignore__: (*optional*) specify a regex that will prevent all matching files from being injected.
-- __prefix__: (*optional*) add a prefix to the file while bundle file would be 
+- __onlinePath__: (*optional*) add an onlinePath prefix to the file while bundle file would be 
   pushed into CDN instead of a local file.
 
 ## License

--- a/examples/rollup.config.js
+++ b/examples/rollup.config.js
@@ -4,13 +4,15 @@ import html from '../src/index';
 export default {
   input: 'src/index.js',
   output: {
-    file: 'dist/bundle-[hash].js',
+    file: 'dist/foo/bundle-[hash].js',
     format: 'iife',
   },
   plugins: [
     html({
       template: 'src/index.html',
       filename: 'index.html',
+      dest: "dist/",
+      prefix: '//www.sohu.com/test/',
       // inject: 'head',
       externals: [
         { type: 'js', file: 'https://test.js', inject: 'head' }

--- a/examples/rollup.config.js
+++ b/examples/rollup.config.js
@@ -12,7 +12,7 @@ export default {
       template: 'src/index.html',
       filename: 'index.html',
       dest: "dist/",
-      prefix: '//www.sohu.com/test/',
+      onlinePath: '//www.sohu.com/test/',
       // inject: 'head',
       externals: [
         { type: 'js', file: 'https://test.js', inject: 'head' }

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ function isURL(url){
 }
 
 export default (opt = {}) => {
-	const { template, filename, externals, inject, dest, absolute, ignore } = opt;
+	const { template, filename, externals, inject, dest, absolute, ignore, prefix } = opt;
 
 	return {
 		name: 'html',
@@ -61,7 +61,6 @@ export default (opt = {}) => {
 
 			fileList.forEach(node => {
 				let { type, file } = node;
-
 				if (ignore && file.match(ignore)) {
 					return;
 				}
@@ -95,8 +94,13 @@ export default (opt = {}) => {
 					writeFileSync(file, code);
 				}
 
+				
 				let src = isURL(file) ? file : absolutePathPrefix + relative(destDir, file).replace(/\\/g, '/');
-
+				if (prefix) { 
+					const filename = file.split('/').slice(-1)[0];
+					const divide = filename.slice(-1) === '/' ? '' : '/';
+					src = prefix + divide + filename;
+				}
 				if (node.timestamp) {
                     src += '?t=' + (new Date()).getTime();
 				}

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ function isURL(url){
 }
 
 export default (opt = {}) => {
-	const { template, filename, externals, inject, dest, absolute, ignore, prefix } = opt;
+	const { template, filename, externals, inject, dest, absolute, ignore, onlinePath } = opt;
 
 	return {
 		name: 'html',
@@ -96,10 +96,10 @@ export default (opt = {}) => {
 
 				
 				let src = isURL(file) ? file : absolutePathPrefix + relative(destDir, file).replace(/\\/g, '/');
-				if (prefix) { 
+				if (onlinePath) { 
 					const filename = file.split('/').slice(-1)[0];
-					const divide = filename.slice(-1) === '/' ? '' : '/';
-					src = prefix + divide + filename;
+					const slash = onlinePath.slice(-1) === '/' ? '' : '/';
+					src = onlinePath + slash + filename;
 				}
 				if (node.timestamp) {
                     src += '?t=' + (new Date()).getTime();


### PR DESCRIPTION
I add a `prefix` option to make sure we can reset the prefix if we want to push the files into CDN after building.

In my case, I would build the bundle files first and then upload them to CDN. I should use a online url  instead of a relative file path. Current options might cover the case too but are not so elegant.